### PR TITLE
fix: Provider and Consumer Playground

### DIFF
--- a/packages/platform/web/apps/complete-application/src/app/api/onboard-api/route.ts
+++ b/packages/platform/web/apps/complete-application/src/app/api/onboard-api/route.ts
@@ -16,6 +16,13 @@ export interface OnboardAPI {
   description: string;
   documentation_url: string;
   required_headers: RequiredHeader[];
+  query_params?: { key: string; value: string }[];
+  body?: {
+    type: string;
+    content: string;
+    form_data?: { key: string; value: string }[];
+    json_data?: any;
+  };
 }
 
 export interface OnboardResponse {
@@ -38,10 +45,21 @@ export interface OnboardUpdateAPI extends OnboardAPI {
     name: string;
     is_active: boolean;
   }[];
+  query_params?: { key: string; value: string }[];
+  body?: {
+    type: string;
+    content: string;
+    form_data?: { key: string; value: string }[];
+    json_data?: any;
+  };
 }
 
 export async function onboardAPI(data: OnboardAPI, token: string): Promise<OnboardResponse> {
   try {
+    console.log('[onboardAPI] Creating API with data:', data);
+    console.log('[onboardAPI] Query params:', data.query_params);
+    console.log('[onboardAPI] Body data:', data.body);
+
     const response = await fetch(`${API_BASE_URL}/onboard`, {
       method: 'PUT',
       headers: {
@@ -114,6 +132,11 @@ export async function getAllOnboardAPIs(token: string): Promise<OnboardAPI[]> {
 
 export async function updateOnboardAPI(apiId: string, data: OnboardUpdateAPI, token: string): Promise<OnboardResponse> {
   try {
+
+    console.log('[updateOnboardAPI] Updating API with data:', apiId, data);
+    console.log('[updateOnboardAPI] Query params:', data.query_params);
+    console.log('[updateOnboardAPI] Body data:', data.body);
+
     const response = await fetch(`${API_BASE_URL}/onboard/api/${apiId}`, {
       method: 'PATCH',
       headers: {

--- a/packages/platform/web/apps/complete-application/src/app/projects/[project_id]/client/[api_id]/page.tsx
+++ b/packages/platform/web/apps/complete-application/src/app/projects/[project_id]/client/[api_id]/page.tsx
@@ -401,6 +401,8 @@ export default function RequestPage() {
           version: "1.0",
           documentation_url: requestData.documentation_url,
           required_headers,
+          query_params: requestData.query_params,
+          body: requestData.body,
         };
 
         if (accessToken) {
@@ -443,6 +445,8 @@ export default function RequestPage() {
           method: requestData.method.toUpperCase(),
           documentation_url: requestData.documentation_url,
           required_headers,
+          query_params: requestData.query_params,
+          body: requestData.body,
           project_id: Number(params.project_id),
         };
 

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/body.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/body.tsx
@@ -1,16 +1,50 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import FormUrlEncoded from "./form-url-encoded";
 import Multipart from "./multipart";
 import JsonEditor from "./json-editor";
 
-export default function Body() {
+interface BodyProps {
+  onBodyChange?: (data: {
+    type: string;
+    content: string;
+    form_data?: { key: string; value: string }[];
+    json_data?: any;
+  }) => void;
+}
+
+export default function Body({ onBodyChange }: BodyProps) {
   const [bodyType, setBodyType] = useState("text");
   const [textContent, setTextContent] = useState("");
   const [graphqlContent, setGraphqlContent] = useState("");
+  const [formData, setFormData] = useState<{ key: string; value: string }[]>([]);
+  const [jsonData, setJsonData] = useState<any>(null);
+
+  const notifyBodyChange = () => {
+    if (onBodyChange) {
+      onBodyChange({
+        type: bodyType,
+        content: bodyType === "text" ? textContent : bodyType === "graphql" ? graphqlContent : "",
+        form_data: bodyType === "form-url-encoded" ? formData : undefined,
+        json_data: bodyType === "json" ? jsonData : undefined,
+      });
+    }
+  };
+
+  useEffect(() => {
+    notifyBodyChange();
+  }, [bodyType, textContent, graphqlContent, formData, jsonData]);
+
+  const handleFormDataChange = (data: { key: string; value: string }[]) => {
+    setFormData(data);
+  };
+
+  const handleJsonChange = (data: any) => {
+    setJsonData(data);
+  };
 
   return (
     <div className="space-y-4">
@@ -31,13 +65,13 @@ export default function Body() {
           />
         </TabsContent>
         <TabsContent value="json" className="space-y-4">
-          <JsonEditor />
+          <JsonEditor onJsonChange={handleJsonChange} />
         </TabsContent>
         <TabsContent value="form-url-encoded" className="space-y-4 max-h-[270px] overflow-y-auto">
-          <FormUrlEncoded />
+          <FormUrlEncoded onFormDataChange={handleFormDataChange} />
         </TabsContent>
         <TabsContent value="multipart" className="space-y-4 max-h-[270px] overflow-y-auto pb-8">
-          <Multipart />
+          <Multipart onFormDataChange={handleFormDataChange} />
         </TabsContent>
         <TabsContent value="graphql" className="space-y-4">
           <Input

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/body.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/body.tsx
@@ -17,7 +17,7 @@ interface BodyProps {
 }
 
 export default function Body({ onBodyChange }: BodyProps) {
-  const [bodyType, setBodyType] = useState("text");
+  const [bodyType, setBodyType] = useState("json");
   const [textContent, setTextContent] = useState("");
   const [graphqlContent, setGraphqlContent] = useState("");
   const [formData, setFormData] = useState<{ key: string; value: string }[]>([]);

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/form-url-encoded.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/form-url-encoded.tsx
@@ -2,7 +2,11 @@
 
 import { KeyValuePair } from "./key-value-pair";
 
-export default function FormUrlEncoded() {
+interface FormUrlEncodedProps {
+  onFormDataChange?: (data: { key: string; value: string }[]) => void;
+}
+
+export default function FormUrlEncoded({ onFormDataChange }: FormUrlEncodedProps) {
   return (
     <KeyValuePair
       title="Form URL Encoded"
@@ -14,6 +18,12 @@ export default function FormUrlEncoded() {
       onChange={(pairs) => {
         // Handle form-url-encoded data changes
         console.log("Form URL Encoded data:", pairs);
+        if (onFormDataChange) {
+          const formData = pairs
+            .filter(pair => pair.key.trim() !== "" && pair.value.trim() !== "")
+            .map(pair => ({ key: pair.key, value: pair.value }));
+          onFormDataChange(formData);
+        }
       }}
     />
   );

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/json-editor.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/json-editor.tsx
@@ -28,8 +28,8 @@ interface JsonEditorProps {
 }
 
 export default function JsonEditor({ onJsonChange }: JsonEditorProps) {
-  const [jsonInput, setJsonInput] = useState(JSON.stringify(sampleData, null, 2))
-  const [parsedData, setParsedData] = useState(sampleData)
+  const [jsonInput, setJsonInput] = useState("")
+  const [parsedData, setParsedData] = useState<any>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -59,7 +59,7 @@ export default function JsonEditor({ onJsonChange }: JsonEditorProps) {
             value={jsonInput}
             onChange={handleJsonInputChange}
             className="font-mono flex-1 resize-none"
-            placeholder="Enter your JSON here..."
+            placeholder={JSON.stringify(sampleData, null, 2)}
           />
           {error && (
             <Alert variant="destructive" className="mt-4">
@@ -69,7 +69,7 @@ export default function JsonEditor({ onJsonChange }: JsonEditorProps) {
           )}
         </div>
         <div className="border rounded-lg p-4 bg-card overflow-auto h-full">
-          <JsonViewer data={parsedData} rootName="data" />
+          <JsonViewer data={parsedData ?? {}} rootName="data" />
         </div>
       </div>
     </div>

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/json-editor.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/json-editor.tsx
@@ -3,7 +3,7 @@
 import { JsonViewer } from "./json-tree-viewer"
 import { Textarea } from "@/components/ui/textarea"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 const sampleData = {
   string: "Hello, world!",
@@ -23,10 +23,20 @@ const sampleData = {
   createdAt: new Date(),
 }
 
-export default function JsonEditor() {
+interface JsonEditorProps {
+  onJsonChange?: (data: any) => void;
+}
+
+export default function JsonEditor({ onJsonChange }: JsonEditorProps) {
   const [jsonInput, setJsonInput] = useState(JSON.stringify(sampleData, null, 2))
   const [parsedData, setParsedData] = useState(sampleData)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (onJsonChange && !error) {
+      onJsonChange(parsedData);
+    }
+  }, [parsedData, error, onJsonChange]);
 
   const handleJsonInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value
@@ -43,8 +53,8 @@ export default function JsonEditor() {
 
   return (
     <div className="container py-10 max-w-7xl">
-      <div className="grid grid-cols-1 gap-4 h-[calc(100vh-8rem)]">
-        <div className="border rounded-lg p-4 bg-card flex flex-col">
+      <div className="grid grid-cols-1 grid-rows-2 gap-4 h-[calc(100vh-22rem)]">
+        <div className="border rounded-lg p-4 bg-card flex flex-col h-full">
           <Textarea
             value={jsonInput}
             onChange={handleJsonInputChange}
@@ -58,7 +68,7 @@ export default function JsonEditor() {
             </Alert>
           )}
         </div>
-        <div className="border rounded-lg p-4 bg-card overflow-auto">
+        <div className="border rounded-lg p-4 bg-card overflow-auto h-full">
           <JsonViewer data={parsedData} rootName="data" />
         </div>
       </div>

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/multipart.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/multipart.tsx
@@ -2,7 +2,11 @@
 
 import { KeyValuePair } from "./key-value-pair";
 
-export default function Multipart() {
+interface MultipartProps {
+  onFormDataChange?: (data: { key: string; value: string }[]) => void;
+}
+
+export default function Multipart({ onFormDataChange }: MultipartProps) {
   return (
     <KeyValuePair
       title="Multipart Form Data"
@@ -14,6 +18,12 @@ export default function Multipart() {
       onChange={(pairs) => {
         // Handle multipart form data changes
         console.log("Multipart form data:", pairs);
+        if (onFormDataChange) {
+          const formData = pairs
+            .filter(pair => pair.key.trim() !== "" && pair.value.trim() !== "")
+            .map(pair => ({ key: pair.key, value: pair.value }));
+          onFormDataChange(formData);
+        }
       }}
     />
   );

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/components/query.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/components/query.tsx
@@ -29,6 +29,10 @@ interface QueryPair {
   value: string;
 }
 
+interface QueryProps {
+  onQueryChange?: (queries: QueryPair[]) => void;
+}
+
 function SortableQueryItem({ query, index, updateQuery, removeQuery }: {
   query: QueryPair;
   index: number;
@@ -98,7 +102,7 @@ function SortableQueryItem({ query, index, updateQuery, removeQuery }: {
   );
 }
 
-export function Query() {
+export function Query({ onQueryChange }: QueryProps) {
   const [queries, setQueries] = useState<QueryPair[]>([
     { id: "1", key: "", value: "" }
   ]);
@@ -110,20 +114,33 @@ export function Query() {
     })
   );
 
+  const notifyQueryChange = (queriesList: QueryPair[]) => {
+    if (onQueryChange) {
+      const validQueries = queriesList.filter(
+        query => query.key.trim() !== '' && query.value.trim() !== ''
+      );
+      onQueryChange(validQueries);
+    }
+  };
+
   const addNewQuery = () => {
-    setQueries([...queries, { id: Date.now().toString(), key: "", value: "" }]);
+    const newQueries = [...queries, { id: Date.now().toString(), key: "", value: "" }];
+    setQueries(newQueries);
+    notifyQueryChange(newQueries);
   };
 
   const updateQuery = (id: string, field: "key" | "value", value: string) => {
-    setQueries(
-      queries.map((query) =>
-        query.id === id ? { ...query, [field]: value } : query
-      )
+    const newQueries = queries.map((query) =>
+      query.id === id ? { ...query, [field]: value } : query
     );
+    setQueries(newQueries);
+    notifyQueryChange(newQueries);
   };
 
   const removeQuery = (id: string) => {
-    setQueries(queries.filter((query) => query.id !== id));
+    const newQueries = queries.filter((query) => query.id !== id);
+    setQueries(newQueries);
+    notifyQueryChange(newQueries);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -132,8 +149,9 @@ export function Query() {
     if (over && active.id !== over.id) {
       const oldIndex = queries.findIndex((query) => query.id === active.id);
       const newIndex = queries.findIndex((query) => query.id === over.id);
-
-      setQueries(arrayMove(queries, oldIndex, newIndex));
+      const newQueries = arrayMove(queries, oldIndex, newIndex);
+      setQueries(newQueries);
+      notifyQueryChange(newQueries);
     }
   };
 

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
@@ -392,7 +392,7 @@ export default function Request({
            <div className="flex gap-2">
             <Button
               onClick={handleTest}
-              disabled={isTestLoading}
+              disabled={isTestLoading || initialData?.path == "" }
               variant="secondary"
               size="sm"
               className="min-w-[80px]"

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
@@ -80,9 +80,17 @@ interface RequestData {
 }
 
 interface TestRequestData {
-  method: string;
-  target_url: string;
   headers: { name: string; value: string }[];
+  api_id: string;
+  project_id: number;
+  name: string;
+  path: string;
+  target_url: string;
+  method: string;
+  version: string;
+  required_headers: { name: string; value: string; is_variable: boolean }[];
+  description: string;
+  documentation_url: string;
 }
 
 const options = new Map([
@@ -284,28 +292,12 @@ export default function Request({
       console.log("🧪 Testing API with payload:", payload);
       console.log("🌐 Making request to:", `${API_BASE_URL}/onboard/test`);
 
-      const response = await fetch(`${API_BASE_URL}/onboard/test`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(accessToken ? { "Authorization": `Bearer ${accessToken}` } : {}),
-        },
-        body: JSON.stringify(payload),
-      });
-
-      const result = await response.json();
-      console.log("📊 Test API response:", result);
-
-      if (!response.ok) {
-        console.log("❌ Test API failed with status:", response.status);
-        throw new Error(result.message || "Test API call failed");
-      }
-
+      if (onTest) {
+      await onTest(payload as TestRequestData);
+    }
       console.log("✅ Test API successful");
-      alert("Test successful: " + JSON.stringify(result.data));
     } catch (error) {
       console.log("❌ Test API error:", error);
-      alert("Test failed: " + (error instanceof Error ? error.message : error));
     } finally {
       setIsTestLoading(false);
     }


### PR DESCRIPTION
- [fix: provider and consumer playground](https://github.com/RiyaRaj28/veil/commit/66ebb6eb58547e5c4751061ab7df0bb3a886c3e1)

- add functionality to onboard body and query params for all types of APIS

- fix double apiId in test request URL of consumer playground

- add Content-Type and X-Subscription-Key (if not already present) in Headers, Curl and Test Request in Consumer Playground

- [remove sample data in jsonviewer of provider playground](https://github.com/RiyaRaj28/veil/commit/f24f69bcd91147b1456eec7dec23ed7cb0174ba4)

- [use json as default tab in body of provider playground](https://github.com/RiyaRaj28/veil/commit/cf6a96244b08e38de0e313bc5020c54c4fa2c265)

- [disable test button if api is not onboarded yet](https://github.com/RiyaRaj28/veil/commit/6ef995c1b518d293ab792450352e92d6bd08f537)

- [update testing ui for provider playground instead of alert message](https://github.com/RiyaRaj28/veil/commit/6ed43f98c257f8235eacaaa2027c7353ece79b53)